### PR TITLE
chown the logs directory to vcap:vcap

### DIFF
--- a/jobs/ulimit/templates/pre-start.sh.erb
+++ b/jobs/ulimit/templates/pre-start.sh.erb
@@ -2,6 +2,10 @@
 
 set -ex
 
+LOG_DIR=/var/vcap/sys/log/ulimit
+
+chown -R vcap:vcap $LOG_DIR
+
 cp -f /var/vcap/jobs/ulimit/etc/limits.conf /etc/security/limits.d/62-ulimit.conf
 
 monit_pid=$( ps -e | grep monit | awk '{print $1}' )


### PR DESCRIPTION
If colocated jobs try to read the logs directory (yes, its empty ... but they still try) as a non-root user ( eg http://bosh.io/jobs/blackbox?source=github.com/concourse/concourse&version=3.8.0 ), they fail to read the directory due to insufficient permissions.

