### PR TITLE
Fix ulimit for Xenial

### DIFF
--- a/jobs/ulimit/templates/pre-start.sh.erb
+++ b/jobs/ulimit/templates/pre-start.sh.erb
@@ -2,10 +2,15 @@
 
 set -ex
 
-cp -f /var/vcap/jobs/ulimit/etc/limits.conf /etc/security/limits.d/62-ulimit.conf
+echo "DefaultLimitNOFILE=<%= p("nofile.soft") %>:<%= p("nofile.hard") %>" >> /etc/systemd/system.conf
+systemctl daemon-reload
 
-monit_pid=$( ps -e | grep monit | awk '{print $1}' )
+pid=$(ps -e | grep monit | awk '{print $1}')
 
-if [ ! -z "$monit_pid" ]; then
-  /var/vcap/packages/pivotal_prlimit/bin/pivotal_prlimit -n $monit_pid  <%= p("nofile.soft") %> <%= p("nofile.hard") %>
-fi
+while [[ $pid -gt 1 ]]; do
+  if [ ! -z "$pid" ]; then
+    /var/vcap/packages/pivotal_prlimit/bin/pivotal_prlimit -n $pid <%= p("nofile.soft") %> <%= p("nofile.hard") %>
+  fi
+
+  pid=$(ps -o ppid= -p $pid)
+done


### PR DESCRIPTION
- set systemd default open file limit and reloads it
- set the ulimit for monit and its parent processes in pre-start script
- remove deprecated trusty limits.conf copying

Co-authored-by: Kai Hofstetter <kai.hofstetter@sap.com>